### PR TITLE
Clarify 'describe your project' question in Issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature---enhacement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature---enhacement-proposal.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Describe the project you are working on:**
+**You should have a live or in-development project/task/tool that you cannot complete as desired without this proposal. If so, please describe it:**
 
 **Describe how this feature / enhancement will help your project:**
 


### PR DESCRIPTION
cc @Xrayez @clayjohn 

Closes #39 so-to-speak. Questions won't be removed, but they can be reworded for clarity. The intent is to restrict proposals to only those that are relevant for actual work being done by the community (things that solve real obstacles / use-cases). The first question is meant to elicit an explanation of what that use-case is, put the proposal into context, and ward away people who are creating Issues just to request things they would *like* to have rather than *need* to have (as contributors do not have time/manpower to implement other features). It now more accurately states that the user must be trying to address a real problem in a real project, tool, or other type of task - and if they aren't, then they shouldn't be making a proposal.