### PR TITLE
Disallow creating blank issues, add a link to the main Godot repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# All proposals must follow the template, so disallow creating blank issues.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Main Godot repository
+  - url: https://github.com/godotengine/godot
+  - about: Please report bugs on the main Godot repository, not here.


### PR DESCRIPTION
See https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository.