### PR TITLE
Combine "Show a mock up" and "Describe implementation" into one item

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature---enhacement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature---enhacement-proposal.md
@@ -18,9 +18,7 @@ Proposals not following the template below will be closed immediately.
 
 **Describe how this feature / enhancement will help you overcome this problem or limitation:**
 
-**Show a mock up screenshots/video or a flow diagram explaining how your proposal will work:**
-
-**Describe implementation detail for your proposal (in code), if possible:**
+**Describe how your proposal will work, with code, pseudocode, mockups, and/or diagrams:**
 
 **If this enhancement will not be used often, can it be worked around with a few lines of script?:**
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2019 Godot Engine contributors.
+Copyright (c) 2014-2020 Godot Engine contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Implements the idea in this comment: https://github.com/godotengine/godot-proposals/issues/10#issuecomment-564621416

If it's a feature used in code, then I don't think screenshots or a flow chart are relevant, let alone necessary. If it's a graphical feature, then the details of the implementation in code usually aren't important (and are basically asking the user to write (pesudo)code for what would be in a PR). So users really only need to do one of these things to explain how the feature will work (but at the same time, this PR doesn't forbid doing both if needed).

This PR also updates the year in the license file, since that needed to be done anyway.