### PR TITLE
Add guideline for evaluating proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ this repository is used to centralize all the proposals in one place
 apart from bug reports.
 
 Proposals are made by opening issues in this repository, which will
-then be discussed with fellow Godot users and contributors. Once a
+then be discussed with fellow Godot users and contributors. If a
 proposal is considered good to implement, it will be approved by a
 core developer.
 
-#### Rules for Submitting a Proposal
+## Rules for submitting a proposal
 
 1. Only proposals that properly fill out the template will be considered. If
 the template is not filled out or is filled out improperly, it will be closed.
@@ -21,28 +21,24 @@ proposal, it is not enough to say it would be "nice" or "helpful". Use the
 template to show how Godot is not currently meeting your needs and then
 explain how your proposal will meet a particular need. 
 
-3. Proposals have similar requirements to Pull Requests (PRs) in the main repository.
-The graph in [this article](https://godotengine.org/article/will-your-contribution-be-merged-heres-how-tell)
-outlines what core developers consider when evaluating your PR/proposal.
-
-4. Other users must express interest in your proposal for it to be considered.
+3. Other users must express interest in your proposal for it to be considered.
 Godot is community-driven, if no other users are interested in your proposal,
 it may be closed. It is up to you to draw interest in your proposed feature.
 Start by reaching out on the community channels (Reddit, Discord, IRC, etc.
 see the [Community Channels](http://docs.godotengine.org/en/stable/community/channels.html) doc),
 then create your proposal once you have gained some interest.
 
-5. You can make a PR implementing the feature in the main repository before 
-making a proposal. However, if it is a large change, a core developer may 
+4. You can make a PR implementing the feature in the main repository before
+making a proposal. However, if it is a large change, a core developer may
 require that you make a proposal before your PR can be merged. It is always
 better to make and discuss a proposal before spending your time implementing
 a new feature.
 
-6. If you or another user is capable of making a PR, include that fact in 
-the issue or in a subsequent comment so that a core contributor can 
+5. If you or another user is capable of making a PR, include that fact in
+the issue or in a subsequent comment so that a core contributor can
 fast-track the approval process.
 
-**What to do if your proposal is closed**
+## What to do if your proposal is closed
 
 If your proposal was closed because the template was not filled out, then 
 fill out the template and ask the person who closed the issue to re-open it.
@@ -55,3 +51,59 @@ If your proposal was closed because a core contributor determined that it was
 not worth pursuing and you feel that it was wrongly closed, then feel free
 to join the developer IRC group and have a more in-depth discussion with 
 other core developers about the feature.
+
+## How core developers evaluate proposals
+
+The following is a list of considerations that core developers use when deciding
+to accept, close, or leave a proposal open. It is intended to be useful for core
+developers when considering proposals and for proposal-makers in drafting their
+proposals.
+
+#### 1. Does the proposal comply with the rules?
+Read the proposal and check to see that it complies with the above-stated rules.
+If it does not, close the proposal.
+
+#### 2. How much support is the proposal receiving?
+Evaluate the amount of support the proposal is receiving. This is an ongoing
+analysis. If a proposal receives little support at first, it may receive
+additional support later on.
+
+#### 3. Can this proposal be implemented with an addon?
+Evaluate whether it is possible for the proposal to be implemented in an addon.
+If it is possible for the proposal to be in an addon, it is less likely to be
+accepted. 
+
+#### 4. Does this proposal benefit most users?
+Determine whether this proposal benefits all users, or just certain users.
+For example, a feature that can only be used for 3D FPS games is less
+likely to be accepted than a feature that benefits all 3D games.
+
+#### 5. Can this proposal be implemented in a robust, general-purpose way?
+Determine whether the feature can be implemented in a robust way that benefits
+all use-cases. For example, many games use an inventory system, but every game
+implements inventory differently. Accordingly, a proposal for an inventory 
+system will likely not be accepted because it would be impossible for us to 
+implement an inventory system that works for most users that need an inventory
+in their game.
+
+#### 6. Does this proposal help users overcome a limitation?
+Proposals that overcome a specific limitation are more likely to be accepted
+than proposals that are just helpful. In short, need-to-have features will be
+prioritized over nice-to-have features. Further, the core developers prioritize
+changes that enable users to implement features themselves over implementing
+those same features in core.
+
+#### 7. How complex would the proposed feature be?
+A highly complex new feature involving substantial changes to core is less likely
+to be accepted than a feature that can be contained within a single node, or a
+group of nodes.
+
+#### 8. Can the feature be worked around in script with a few lines?
+If the feature is only intended to save users a few lines of code it is unlikely
+to be accepted.
+
+The above considerations are all balanced, no one is more important than another.
+Core developers have discretion to weigh the factors as they see fit.
+
+In addition to the above guideline, consider [this article](https://docs.godotengine.org/en/latest/community/contributing/best_practices_for_engine_contributors.html)
+which outlines what core developers consider when evaluating PRs.


### PR DESCRIPTION
This adds a lot of clarification to the process used for selecting and rejecting proposals. This should assist users in writing proposals and should assist reviewers in applying clear and fair criteria to proposals. 

All these considerations have been in use, and have been discussed among the core developers, but have not been formally verbalized yet.