### PR TITLE
Link Godot Ideas repository as an alternative for GIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ individually.
 proposal, it is not enough to say it would be "nice" or "helpful". Use the
 template to show how Godot is not currently meeting your needs and then
 explain how your proposal will meet a particular need.
+   * If you feel that you cannot provide highly detailed instructions with the
+     proposal, consider creating a more simple, open-ended issue in the
+     unofficial, community-maintained
+     [Godot Ideas](https://github.com/godot-extended-libraries/godot-ideas)
+     repository.
 
 4. Other users must express interest in your proposal for it to be considered.
 Godot is community-driven: if no other users are interested in your proposal,


### PR DESCRIPTION
Resolves #39.
Resolves #47.
Closes #91, as suggested by @Calinou in https://github.com/godotengine/godot-proposals/issues/91#issuecomment-688850693.
Closes #779, similar suggestion by @aaronfranke in https://github.com/godotengine/godot-proposals/issues/779#issuecomment-625595439, with the 👍 from the OP.

Currently, GIP has a requirement that proposals must describe a concrete use case to justify making a proposal:

> All proposals must be linked to a substantive use-case. In justifying your proposal, it is not enough to say it would be "nice" or "helpful". Use the template to show how Godot is not currently meeting your needs and then explain how your proposal will meet a particular need.

This pull request amends the third rule for submitting a proposal to provide an alternative way to present and discuss ideas in the [`Godot Ideas`](https://github.com/godot-extended-libraries/godot-ideas) repository (unofficial) in case people do not have any concrete use cases to justify the proposal.