### PR TITLE
Clarify the rule regarding the requirement for filling out the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ Don't fork this repository to open a proposal.
 
 ## Rules for submitting a proposal
 
-1. Only proposals that properly fill out the template will be considered. If
-the template is not filled out or is filled out improperly, it will be closed.
+1. Only proposals that fill out the template completely will be considered. You
+are free to answer the questions as you see fit, but do note that high-quality,
+elaborate proposals are more likely to be accepted. The template is there to
+help you think on the matter, and may not always apply to your particular
+proposal. But if a proposal misses some vital information as suggested in the
+template, it *may* be closed. Likewise, if a proposal contains inappropriate
+content, it *will* be closed.
 
 2. Please open one proposal per feature requested. Do not cram multiple feature
 requests in a single proposal, as this makes it harder to discuss features


### PR DESCRIPTION
Closes #1634.

A similar suggestion was raised a year ago with no consensus reached in #39, but the general problem still persists as seen in #1634.

This PR clarifies that a proposal is evaluated by content, not structure (I hope that proposals are not evaluated by structure), so it's perfectly fine to omit the questions if they do not apply to a proposal. That said, if a proposal misses some *vital* information as suggested in the template, it may be closed indeed, but the proposal text can be anything as long as it's elaborate/complete/self-sufficient.

At least that's the way I'd like this to be. But do note that I haven't changed anything semantically, I believe this reflects the current situation more accurately than the former wording which is a bit unwelcoming in contrast.

Also, this elaborates on what kind of proposal is seen as proper, because the "proper" word is too vague, in my opinion.
