### PR TITLE
Use header text rather than bold text for categories

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature---enhancement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature---enhancement-proposal.md
@@ -12,14 +12,14 @@ Please fill in *all* the questions below and don't remove any of them.
 Proposals not following the template below will be closed immediately.
 -->
 
-**Describe the project you are working on:**
+### Describe the project you are working on
 
-**Describe the problem or limitation you are having in your project:**
+### Describe the problem or limitation you are having in your project
 
-**Describe the feature / enhancement and how it helps to overcome the problem or limitation:**
+### Describe the feature / enhancement and how it helps to overcome the problem or limitation
 
-**Describe how your proposal will work, with code, pseudocode, mockups, and/or diagrams:**
+### Describe how your proposal will work, with code, pseudo-code, mock-ups, and/or diagrams
 
-**If this enhancement will not be used often, can it be worked around with a few lines of script?:**
+### If this enhancement will not be used often, can it be worked around with a few lines of script?
 
-**Is there a reason why this should be core and not an add-on in the asset library?:**
+### Is there a reason why this should be core and not an add-on in the asset library?


### PR DESCRIPTION
I've made several proposals here and I almost always notice the lack of hierarchy between user-provided text and the template-given text.

This PR changes the bold text to header text (MD `###`).

# Before:
> **Describe the project you are working on:**
> Godot Proposals Pull Request

# After:
> ### Describe the project you are working on
> Godot Proposals Pull Request

---

The old behaviour was annoying when adding my own categories or "important text". For example, the PR I made today:
> **Describe the problem or limitation you are having in your project:**
> The "Please confirm" dialog is just an extra step when it comes to deleting files.
> 
> **What causes the popup?**
> **Delete Keyboard Shortcut**: I guarantee that the vast majority of people deleting with the keyboard shortcut "Del" just immediately hit enter without looking at the dialogue- it's just muscle memory. Therefore, for most cases the popup doesn't even do it's job of making sure accidental deletions don't occur.
> 
> **Delete from option menu**: The popup also doesn't serve much of a purpose here. The user takes a relatively long time right clicking the files and then going to the delete option. I think the only accidental use of Delete would be mistakenly hitting it instead of "Move To", which I doubt is a common occurrence.
> 
> **Describe the feature / enhancement and how it helps to overcome the problem or limitation:**
> First of all, this popup should be removed. It's just an annoyance and as stated earlier rarely truly does its job.

I wanted to draw attention to the causes of the behaviour, but the only way to do it makes it seem like those were separate categories even though all of the text was part of the `Describe the problem or limitation` category.

---

**Note that this PR also adds hyphens to `pseudo-code` and `mock-ups` to fix their grammar.**