### PR TITLE
Replace "Rules" to "Recommendations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Don't fork this repository to open a proposal.
 > to view all open proposals on a single page. This allows for easy searching
 > in proposal titles using <kbd>Ctrl + F</kbd>.
 
-## Rules for submitting a proposal
+## Recommendations for submitting a proposal
 
 1. Only proposals that properly fill out the template will be considered. If
 the template is not filled out or is filled out improperly, it will be closed.


### PR DESCRIPTION
The "rule" is not the best word to describe the intention behind those statements. In a community-driven project, it's not actually possible to enforce a particular behavior. Therefore, the "recommendation" word is better suited to convey this message.

Supersedes #1650.