### PR TITLE
Fix broken issue template link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ fast-track the approval process.
 ## What to do if your proposal is closed
 
 If your proposal was closed because the template was not filled out, then
-fill out the [template](.github/ISSUE_TEMPLATE/feature---enhancement-proposal.md)
+fill out the [template](.github/ISSUE_TEMPLATE/feature_enhancement_proposal.yml)
 and ask the person who closed the issue to re-open it.
 
 If your proposal was closed as a duplicate and had a different approach to solving


### PR DESCRIPTION
Hello,

This is very minor, but I was reading through the README for this repository and got a 404 when clicking on the issue template link. It looks like the template file changed a couple months ago from Markdown to YAML in [this PR](https://github.com/godotengine/godot-proposals/pull/2836); it'd be nice to update the README link to match the new file location. 

Thanks! :D 