### PR TITLE
Update Issue Template Rules Link

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.yml
@@ -8,7 +8,7 @@ body:
         - Choose a descriptive title above that differentiates your proposal from other, similar proposals.
 
         ### Before you start
-        - Review the [Rules for submitting a proposal](https://github.com/godotengine/godot-proposals?tab=readme-ov-file#rules-for-submitting-a-proposal). If you fail to comply with them, the proposal will be closed.
+        - Review the [Rules for submitting a proposal](https://github.com/godotengine/godot-proposals?tab=readme-ov-file#rules-for-proposal-issues). If you fail to comply with them, the proposal will be closed.
         - Search [existing proposals](https://github.com/godotengine/godot-proposals/issues?q=is%3Aissue) for related or duplicate proposals.
         - Search the internet and [asset library](https://godotengine.org/asset-library/asset) for assets that could solve your problem without an engine change.
 


### PR DESCRIPTION
This pull request updates the link that points to the rules for Godot proposal issues, since the header has been changed in #14257.